### PR TITLE
Add missing await to channel.set_permissions

### DIFF
--- a/warnsystem/warnsystem.py
+++ b/warnsystem/warnsystem.py
@@ -1363,7 +1363,7 @@ class WarnSystem(SettingsMixin, AutomodMixin, BaseCog, metaclass=CompositeMetaCl
         if not role:
             return
         try:
-            channel.set_permissions(
+            await channel.set_permissions(
                 role,
                 send_messages=False,
                 add_reactions=False,


### PR DESCRIPTION


## Pull request type

on_guild_channel_create does not await channel.set_permissions.

## Description of the changes
add await keyword. tested on latest red stable
